### PR TITLE
specify file encoding when loading csv

### DIFF
--- a/testing model final.Rmd
+++ b/testing model final.Rmd
@@ -115,7 +115,7 @@ beta_censored[1:(6/dt)]<-0
 beta_censored_screen[1:(4/dt)]<-0
 
 #sensitivity of PCR test as a function of time since infection
-sens_data<-read.csv("Wikramanatapluspresymp.csv", stringsAsFactors = F)
+sens_data<-read.csv("Wikramanatapluspresymp.csv", stringsAsFactors = F, fileEncoding="UTF-8-BOM")
 st<-predict(smooth.spline(sens_data$day_exposure, sens_data$sens, spar=0.4),tau)
 st<-apply(data.frame(rep(0,length(st$y)),st$y),1,FUN = max)
 


### PR DESCRIPTION
Wikramanatapluspresymp.csv uses BOM file encoding. Without specifying this when loading the file on the Windows platform, the first column name can be corrupted.